### PR TITLE
[BUG] Don't store the db connection in the global scope

### DIFF
--- a/frontend/.streamlit/config.toml
+++ b/frontend/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+base="light"


### PR DESCRIPTION
## Description
Fixes #20  Set a ttl on the db connection and limited it's scope.

## Implementation
Move the db connection to `data.py`. Re-enable the 5 min cache but don't store the db connection in the global scope. My hypothesis is if the handle is in the global scope, streamlit will think it's in use and attempt to invalidate it's cache every time the ttl expires. If the connection is only accessed when queries are made streamlit shouldn't prematurely invalidate the cache.

## Testing
Ran the app for several minutes and confirmed the db connection wasn't getting recreated.