### PR TITLE
[Bug] Move config file to top level directory

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+base="light"


### PR DESCRIPTION
## Description
Config file needs to be in the top level directory to take effect.

## Implementation
Move to top level directory

## Testing
Confirmed light theme forced.